### PR TITLE
changing yank inside popup to go to unnamed reg, not unnamedplus

### DIFF
--- a/lua/yankbank/menu.lua
+++ b/lua/yankbank/menu.lua
@@ -173,7 +173,7 @@ function M.set_keymaps(win_id, bufnr, yanks, reg_types, line_yank_map, opts)
             local text = yanks[yankIndex]
             -- NOTE: possibly change this to '"' if not using system clipboard
             -- - make this an option
-            vim.fn.setreg("+", text)
+            vim.fn.setreg("@", text)
             vim.api.nvim_win_close(win_id, true)
         end
     end, { buffer = bufnr })


### PR DESCRIPTION
Nice little plugin. I can see myself becoming very reliant on it.

Can I offer the following tweak, which to me makes this more intuitive? The `keymaps.yank` function, when inside the pop-up, silently yanks to the unnamedplus register. I would suggest you use the unnamed reg instead, which then allows someone to quickly put with `p`.

If this doesn't match your workflow, feel free to close without merging this ;)