### PR TITLE
fix: fixed error on yank/delete with no specified opts

### DIFF
--- a/lua/yankbank/clipboard.lua
+++ b/lua/yankbank/clipboard.lua
@@ -45,7 +45,13 @@ function M.setup_yank_autocmd(yanks, reg_types, opts)
                 if #yank_text <= 1 then
                     return
                 end
-                M.add_yank(yanks, reg_types, yank_text, reg_type, opts.max_entries)
+                M.add_yank(
+                    yanks,
+                    reg_types,
+                    yank_text,
+                    reg_type,
+                    opts.max_entries
+                )
             end
         end,
     })
@@ -66,7 +72,13 @@ function M.setup_yank_autocmd(yanks, reg_types, opts)
                     return
                 end
 
-                M.add_yank(yanks, reg_types, yank_text, reg_type, opts.max_entries)
+                M.add_yank(
+                    yanks,
+                    reg_types,
+                    yank_text,
+                    reg_type,
+                    opts.max_entries
+                )
             end,
         })
     end

--- a/lua/yankbank/clipboard.lua
+++ b/lua/yankbank/clipboard.lua
@@ -4,19 +4,23 @@ local M = {}
 -- Function to add yanked text to table
 function M.add_yank(yanks, reg_types, text, reg_type, max_entries)
     -- avoid adding empty strings
-    if text ~= "" and text ~= " " and text ~= "\n" then
-        -- do not update with duplicate values
-        for _, entry in ipairs(yanks) do
-            if entry == text then
-                return
-            end
+    if text == "" and text == " " and text == "\n" then
+        return
+    end
+
+    -- do not update with duplicate values
+    for _, entry in ipairs(yanks) do
+        if entry == text then
+            return
         end
-        table.insert(yanks, 1, text)
-        table.insert(reg_types, 1, reg_type)
-        if #yanks > max_entries then
-            table.remove(yanks)
-            table.remove(reg_types)
-        end
+    end
+
+    table.insert(yanks, 1, text)
+    table.insert(reg_types, 1, reg_type)
+
+    if #yanks > max_entries then
+        table.remove(yanks)
+        table.remove(reg_types)
     end
 end
 
@@ -26,49 +30,46 @@ function M.setup_yank_autocmd(yanks, reg_types, opts)
     -- autocommand to listen for yank events
     vim.api.nvim_create_autocmd("TextYankPost", {
         callback = function()
-            -- TODO: this function can be expanded to incorporate other registers
-            -- - use vim.v.event.regname and an allowlist
-            -- local reg_type = vim.v.event.operator
-            -- if reg_type == "y" or reg_type == "d" then
-            -- local yanked_text = vim.fn.getreg('"')
-
             -- get register information
             local rn = vim.v.event.regname
-            local reg_type = vim.fn.getregtype('"')
 
             -- check if changes were made to default register
-            if vim.v.event.regname == "" then
-                local yank = vim.fn.getreg(rn)
+            if rn == "" or rn == "+" then
+                local reg_type = vim.fn.getregtype(rn)
+                local yank_text = vim.fn.getreg(rn)
 
-                -- NOTE: this only blocks adding to list if something else is in plus register
-                if string.len(yank) <= 1 then
+                if not yank_text or type(yank_text) ~= "string" then
                     return
                 end
 
-                M.add_yank(yanks, reg_types, yank, reg_type, opts.max_entries)
+                if #yank_text <= 1 then
+                    return
+                end
+                M.add_yank(yanks, reg_types, yank_text, reg_type, opts.max_entries)
             end
         end,
     })
 
     -- poll registers when vim is focused (check for new clipboard activity)
-    if opts.focus_gain_poll and opts.focus_gain_poll == true then
+    if opts.focus_gain_poll == true then
         vim.api.nvim_create_autocmd("FocusGained", {
             callback = function()
                 -- get register information
                 local reg_type = vim.fn.getregtype("+")
-                local yank = vim.fn.getreg("+")
+                local yank_text = vim.fn.getreg("+")
 
-                -- NOTE: do not add yanks of 1 or 0 characters
-                if string.len(yank) <= 1 then
+                if not yank_text or type(yank_text) ~= "string" then
                     return
                 end
 
-                M.add_yank(yanks, reg_types, yank, reg_type, opts.max_entries)
+                if string.len(yank_text) <= 1 then
+                    return
+                end
+
+                M.add_yank(yanks, reg_types, yank_text, reg_type, opts.max_entries)
             end,
         })
     end
-
-    -- TODO: focus lost hook?
 end
 
 return M

--- a/lua/yankbank/init.lua
+++ b/lua/yankbank/init.lua
@@ -8,35 +8,39 @@ local clipboard = require("yankbank.clipboard")
 -- initialize yanks tables
 local yanks = {}
 local reg_types = {}
-local max_entries = 10
-local sep = "-----"
+local default_opts = {
+    max_entries = 10,
+    sep = "-----",
+    focus_gain_poll = false,
+    num_behavior = "prefix",
+    registers = {
+        yank_register = "+",
+    },
+    keymaps = { },
+}
 
 -- wrapper function for main plugin functionality
 local function show_yank_bank(opts)
     -- Parse command arguments directly if args are provided as a string
-    opts = opts or {}
+    opts = opts or default_opts
 
-    -- Fallback to defaults if necessary
-    local max_entries_opt = opts.max_entries or max_entries
-    local sep_opt = opts.sep or sep
-    opts.keymaps = opts.keymaps or {}
-
+    -- initialize buffer and populate bank
     local bufnr, display_lines, line_yank_map =
-        menu.create_and_fill_buffer(yanks, reg_types, max_entries_opt, sep_opt)
+        menu.create_and_fill_buffer(yanks, reg_types, opts.max_entries, opts.sep)
+
     -- handle empty bank case
     if not bufnr then
         return
     end
+
+    -- open window and set keybinds
     local win_id = menu.open_window(bufnr, display_lines)
     menu.set_keymaps(win_id, bufnr, yanks, reg_types, line_yank_map, opts)
 end
 
 -- plugin setup
 function M.setup(opts)
-    opts = opts or {}
-
-    -- parse opts
-    max_entries = opts.max_entries or max_entries
+    opts = opts or default_opts
 
     -- create clipboard autocmds
     clipboard.setup_yank_autocmd(yanks, reg_types, opts)

--- a/lua/yankbank/init.lua
+++ b/lua/yankbank/init.lua
@@ -16,7 +16,7 @@ local default_opts = {
     registers = {
         yank_register = "+",
     },
-    keymaps = { },
+    keymaps = {},
 }
 
 -- wrapper function for main plugin functionality
@@ -25,8 +25,12 @@ local function show_yank_bank(opts)
     opts = opts or default_opts
 
     -- initialize buffer and populate bank
-    local bufnr, display_lines, line_yank_map =
-        menu.create_and_fill_buffer(yanks, reg_types, opts.max_entries, opts.sep)
+    local bufnr, display_lines, line_yank_map = menu.create_and_fill_buffer(
+        yanks,
+        reg_types,
+        opts.max_entries,
+        opts.sep
+    )
 
     -- handle empty bank case
     if not bufnr then


### PR DESCRIPTION
Fixed issue on yank/delete with no specified max_entries option in config.

Added better handling of default options in init.lut that should help prevent these issues in the future.